### PR TITLE
minor updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ MAINTAINER Tero Ahonen (tahonen@redhat.com)
 RUN rpm -iUvh http://www.nic.funet.fi/pub/mirrors/fedora.redhat.com/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm && yum -y update && yum -y install git ansible python-pip gcc python-devel libffi-devel openssl-devel libxml2-devel libxslt1-devel libjpeg8-devel zlib1g-devel
 RUN pip install --upgrade pip && pip install msrest --upgrade && pip install msrestazure --upgrade && pip install azure==2.0.0rc5
 RUN git clone https://github.com/ivanthelad/ansible-azure
-COPY install.sh /ansible-azure/
+COPY install.sh /ansible-azure/install.sh
 RUN chmod +x /ansible-azure/install.sh && mkdir /ansible-azure/export
+VOLUME /ansible-azure/group_vars
 WORKDIR ansible-azure
 CMD ./install.sh

--- a/README.md
+++ b/README.md
@@ -9,39 +9,138 @@ Installation is done with Docker container and environmental variables that are 
 * Red Hat account and Openshift Enterprise subscription
 * Docker
 
-## Sample config
+## Sample ALL config
+The following configs are required
+
+* resource_group_name: ivancloud     [This should be unique name ]
+
+* ad_password: XXXXXXXXXXXXXXXXXXX   [Ansible User for azure ]
+
+* subscriptionID: XXXXXXXXXXXXXX     [Ansible pwd for azure ]
+
+* adminUsername: ivan                [User to log into jumphost with ]
+
+* adminPassword: XXx_please_change_me_xXX  [User pwd to log into jumphost with ]
+
+* rh_subcription_user: XXXXXXXXXXX   [RH subscription user ]
+
+* rh_subcription_pass: XXXXXXXXXXX   [RH subscription pwd ]
+
+* openshift_pool_id: XXXXXXXXXXX     [RH subscription pwd ]
 
 ```
-# Name for Azure resource group
-# OSE Master hostname is
-# master-RESOURCE_GROUP_NAME.AZURE_REGION.cloudapp.azure.com
-RESOURCE_GROUP_NAME=zyx
-# Azure compute region
-AZURE_REGION=northeurope
-# Azure AD account username
-AZURE_AD_USERNAME=zyz
-# Azure AD account password
-AZURE_AD_PASSWORD=xyz
-# Azure subscription ID
-AZURE_SUBS_ID=xyz
-# Standard_D1_v2: 1 Core, 3.5 Gb RAM, 50 GB Disk
-# Standard_D2_v2: 2 Core, 7 Gb RAM, 100 GB Disk
-# Standard_D3_v2: 4 Core, 14 Gb RAM, 200 GB Disk
+
+#---
+resource_group_name: pirates
+##  Azure AD user.
+ad_username: XXXXXXXXXXXXXXXXXXX
+### Azure AD password
+ad_password: XXXXXXXXXXXXXXXXXXX
+#resource_group_name: oscp
+#### Azure Subscription ID
+subscriptionID: "XXXXXXXXXXXXXXXXXXX"
+## user to login to the jump host. this user will only be created on the jumphost
+adminUsername: ivan
+## user pwd for jump host
+## Password for the jump host
+adminPassword: XXx_please_change_me_xXX
+##### Public key for jump host. With the Docker installation this will be replaced dynamically
+sshkey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDCdC20wMbD9vmCPDD6VP6u3eYHCznqKOm+aPZi3EgUZIM7r91X7MFzuVS5U6gHXnOa4m7yh26zceh68T6FqIKby1WAGTShLFDCU6czEe0Pa5yMAV6Q4dQ34HyioTIu4HmXi4504ZxneLNJP2AHc+eJkV0ANcXIHSqoaleVyWt7HLNltFNO349GZMj01TSchBYzqZpYqSGIDsTIXwF6+/NosMLfmg6WF0J4M7A34Gn/YTXD8r2oWeSs3O+MdTMH2Zdt4j9Q8MPCgic6xDPiONpCvEdt5pkzrwaK9ZJEV4wZsV7CSy+5a+poOl/a/5F+Mj3qwqwqwFc2IRJiDkScuV07qWthKH
+
+
 # see https://azure.microsoft.com/en-us/documentation/articles/cloud-services-sizes-specs/
-# VM size for master node
-AZURE_VM_SIZE_MASTER=Standard_D1_v2
-# VM size for infra and app nodes
-AZURE_VM_SIZE_NODE=Standard_D1_v2
-# jumphost username
-ADMIN_USERNAME=zyx
-# jumphost password
-ADMIN_PASSWORD=zyx
-# Red Hat account username (access.redhat.com)
-RH_SUBS_USER=xyz
-# Red Hat account password
-RH_SUBS_PASSWORD=xyz
-# Subscription pool id for Openshift packages
-RH_OPENSHIFT_POOL_ID=xyx
+### Size for the master
+master_vmSize: Standard_DS3_v2
+#master_vmSize: Standard_D2_v2
+#master_vmSize: Standard_D1_v2
+
+### Size for the nodes
+node_vmSize: Standard_DS3_v2
+#node_vmSize: Standard_D2_v2
+#node_vmSize: Standard_D1_v2
+
+#### Region to deploy in
+region: northeurope
+
+## docker info
+docker_storage_device: /dev/sdc
+create_vgname: docker_vg
+filesystem: 'xfs'
+create_lvsize: '80%FREE'
+#create_lvsize: '2g'
+
+#### subscription information
+rh_subcription_user: XXXXXXXXXXX
+rh_subcription_pass: XXXXXXXXXXX
+openshift_pool_id: XXXXXXXXXXX
+
+########### list of node  ###########
+### Warning, you currently cannot create more infra nodes ####
+### this will change in the future
+### You can add as many nodes as you want
+#####################################
+jumphost:
+  jumphost1:
+    name: jumphost1
+    tags:
+      region: northeurope
+      zone: jumphost
+      stage: jumphost
+
+masters:
+  master1:
+    name: master1
+    tags:
+      region: northeurope
+      zone: infra
+      stage: none
+#  master2:
+#    name: master2
+#    tags:
+#      region: northeurope
+#      zone: infra
+#      stage: none
+#  master3:
+#    name: master3
+#    tags:
+#      region: northeurope
+#      zone: infra
+#      stage: none
+
+infranodes:
+  infranode1:
+    name: infranode1
+    tags:
+      region: northeurope
+      zone: infra
+      stage: dev
+      type: core
+      infratype: registry
+      mbaas_id: mbaas1
+  infranode2:
+    name: infranode2
+    tags:
+      region: northeurope
+      zone: infra
+      stage: dev
+      type: core
+      mbaas_id: mbaas2
+  infranode3:
+    name: infranode3
+    tags:
+      region: northeurope
+      zone: infra
+      stage: dev
+      type: core
+      mbaas_id: mbaas3
+nodes:
+  node1:
+    name: node1
+    tags:
+      region: northeurope
+      zone: frontend
+      stage: dev
+
 ```
 
 ## Setup
@@ -62,19 +161,30 @@ Open envs.txt to your favorite editor and replace sample values with correct one
 
 Installation will start right after you execute docker run command described below. If you just need to start container and check what it contains add "/bin/bash" at the end of the command. Also if you need to make modifications to number of VMs installed or other tuning, just start the container not the installation. When you are done with your changes just execute /ansible-azure/install.sh.
 
+
+
 If you start installation directly you have to mount a local directory to container so that installer can export SSH key to you. Below example will export key to directory /tmp and the name of the file by default azurekey
+- The installation outputs a newly created KEY  to /tmp/azurekey.$resource_group_name
+
+
+To Perform a installation successfully the following is required
+  - A volume to export the generated key (this will allow you to ssh into your VMS )
+  - A volume that contains a file called "all". The all file is where the azure config resides
+
+in the below example. the folder /Users/imckinle/Projects/openshift/azure-ansible/ansible-azure/group_vars contains the all directory
 
 ```
 # start installation
-docker run -v /tmp:/ansible-azure/export -it --env-file envs.txt ocpazure
+docker run  -v /tmp:/ansible-azure/export  -v  /Users/imckinle/Projects/openshift/azure-ansible/ansible-azure/group_vars:/ansible-azure/group_vars -it ocpazure
 # start container
-docker run -it -v /tmp:/ansible-azure/export --env-file envs.txt ocpazure "/bin/bash"
+docker run -it -v /tmp:/ansible-azure/export  -v  /Users/imckinle/Projects/openshift/azure-ansible/ansible-azure/group_vars:/ansible-azure/group_vars  ocpazure "/bin/bash"
 ```
 
 
 ## Post install stuff
 
 You need newly create SSH key to access jumphost. This key is exeport to given host directory or you can read it from .ssh directory if you started installation manually. If you do not manage to get hold of the key you can change SSH key to jumphost vie Azure portal (https://portal.azure.com). Key is changed from VM settings via Set password.
+   - ssh -i /tmp/azurekey.$groupname
 
 ## TODO
 * Define number of app and infra nodes thru envs.

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 ssh-keygen -q -t rsa -f ~/.ssh/id_rsa -N ""
-cp ~/.ssh/id_rsa ./export/azurekey
-ansible-playbook -i inventory playbooks/init.yml
-ansible-playbook --forks=50 -i invetory playbooks/install_openshift.yml
+touch ~/.ssh/known_hosts
+cp ~/.ssh/id_rsa ./export/azurekey.$(grep  '^resource_group_name:' /ansible-azure/group_vars/all | awk '{ print $2}')
+#o#ansible-playbook -i inventory playbooks/init.yml
+sed -i "/sshkey: /c\sshkey: $(cat /root/.ssh/id_rsa.pub)" /ansible-azure/group_vars/all
+ansible-playbook --forks=50 -i bla  playbooks/setupeverything.yml


### PR DESCRIPTION
- Simpler construct. Mounts the group_var/all file instead of using properties env.txt
- Performs a sed to replace the sshkey in the  file group_var/all with the one thats created in the install.sh
- dumps the rsa_id out to file azurekey.$groupname. this is to allow uses to ssh into the machine. (also because it uses the group name you can create many installs and not overwrite previous key )